### PR TITLE
rename kotlin.KotlinVersion class to kotlin.SbtKotlinVersion

### DIFF
--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinPlugin.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinPlugin.scala
@@ -13,7 +13,7 @@ object KotlinPlugin extends AutoPlugin {
   override def projectConfigurations: Seq[Configuration] = KotlinInternal :: Nil
 
   private def kotlinScriptCompilerDeps(kotlinVer: String, provided: Boolean) = {
-    if (KotlinVersion(kotlinVer) <= KotlinVersion("1.3.21")) {
+    if (SbtKotlinVersion(kotlinVer) <= SbtKotlinVersion("1.3.21")) {
       val kotlinScriptRuntime = "org.jetbrains.kotlin" % "kotlin-script-runtime" % kotlinVer
       val dependency = if (provided) kotlinScriptRuntime % Provided else kotlinScriptRuntime
       Seq(dependency)

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinStub.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinStub.scala
@@ -55,7 +55,7 @@ case class KotlinStub(log: Logger, kref: KotlinReflection) {
 
     // parse method received a new argument in 1.7.0
     // see https://github.com/JetBrains/kotlin/commit/683a3e74a000f959a932505592e1d68a073296cd
-    if (KotlinVersion(kotlinVersion) >= KotlinVersion("1.7.0")) {
+    if (SbtKotlinVersion(kotlinVersion) >= SbtKotlinVersion("1.7.0")) {
       val parserMethod = parser.getMethod(
         parseMethodName,
         stringListClass,

--- a/src/main/scala/org/jetbrains/sbt/kotlin/SbtKotlinVersion.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/SbtKotlinVersion.scala
@@ -4,10 +4,10 @@ import scala.math.Ordered.orderingToOrdered
 import scala.math.Ordering.Implicits.seqDerivedOrdering
 
 // based on https://github.com/JetBrains/intellij-community/blob/c8ba8401f73488f966b5ed5b5c5afaa38a9bcbdf/plugins/kotlin/base/plugin/src/org/jetbrains/kotlin/idea/compiler/configuration/IdeKotlinVersion.kt#L24
-final class KotlinVersion private[kotlin](val major: Int, val minor: Int, val patch: Int,
-                                          val kindSuffix: KotlinVersion.Kind,
-                                          val buildNumber: Option[String]) extends Ordered[KotlinVersion] {
-  override def compare(that: KotlinVersion): Int = {
+final class SbtKotlinVersion private[kotlin](val major: Int, val minor: Int, val patch: Int,
+                                          val kindSuffix: SbtKotlinVersion.Kind,
+                                          val buildNumber: Option[String]) extends Ordered[SbtKotlinVersion] {
+  override def compare(that: SbtKotlinVersion): Int = {
     val base = (major, minor, patch).compare((that.major, that.minor, that.patch))
     if (base != 0) base
     else {
@@ -17,18 +17,18 @@ final class KotlinVersion private[kotlin](val major: Int, val minor: Int, val pa
   }
 
   override def equals(that: Any): Boolean = that match {
-    case version: KotlinVersion => compare(version) == 0
+    case version: SbtKotlinVersion => compare(version) == 0
     case _ => false
   }
 }
 
-object KotlinVersion {
+object SbtKotlinVersion {
   private val kotlinVersionRegex = "^(\\d+)\\.(\\d+)\\.(\\d+)(?:-([A-Za-z]\\w+(?:\\.\\d+)?(?:-release)?))?(?:-(\\d+)?)?$"
     .r("major", "minor", "patch", "kindSuffix", "buildNumber")
 
   private val IdeBuildRegex = "ij\\d+(?:\\.\\d+)?".r
 
-  def apply(versionString: String): KotlinVersion = versionString match {
+  def apply(versionString: String): SbtKotlinVersion = versionString match {
     case kotlinVersionRegex(majorStr, minorStr, patchStr, kindSuffixStr, buildNumberStr) =>
       val majorValue = majorStr.parseVersionComponent("major")
       val minorValue = minorStr.parseVersionComponent("minor")
@@ -58,7 +58,7 @@ object KotlinVersion {
 
       val buildNumber = Option(buildNumberStr).filterNot(_.isEmpty)
 
-      new KotlinVersion(majorValue, minorValue, patchValue, kindSuffix, buildNumber)
+      new SbtKotlinVersion(majorValue, minorValue, patchValue, kindSuffix, buildNumber)
     case _ => throw new IllegalArgumentException(s"Unsupported Kotlin version: $versionString")
   }
 


### PR DESCRIPTION
Hey @vasilmkd . I couldn't find a good way to contact you through other means, this project seem to have issues and discussions closed. So I'm raising this PR to bring attention to what seem to be the problem I'm having.

The issue is, I'm trying to make this compiler work with kotest testing library but every time I run tests I'm getting this error:

```
[error] Caused by: java.lang.NoSuchMethodError: 'void kotlin.KotlinVersion.<init>(int, int)'
[error]         at kotlin.reflect.jvm.internal.impl.load.kotlin.DeserializationComponentsForJavaKt.makeLazyJavaPackageFragmentProvider(DeserializationComponentsForJava.kt:163)
[error]         at kotlin.reflect.jvm.internal.impl.load.kotlin.DeserializationComponentsForJavaKt.makeLazyJavaPackageFragmentProvider$default(DeserializationComponentsForJava.kt:149)
[error]         at kotlin.reflect.jvm.internal.impl.load.kotlin.DeserializationComponentsForJava$Companion.createModuleData(DeserializationComponentsForJava.kt:114)
[error]         at kotlin.reflect.jvm.internal.impl.descriptors.runtime.components.RuntimeModuleData$Companion.create(RuntimeModuleData.kt:32)
[error]         at kotlin.reflect.jvm.internal.ModuleByClassLoaderKt.getOrCreateModule(moduleByClassLoader.kt:58)
[error]         at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data.moduleData_delegate$lambda$0(KDeclarationContainerImpl.kt:38)
[error]         at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data.accessor$KDeclarationContainerImpl$Data$lambda0(KDeclarationContainerImpl.kt)
[error]         at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data$$Lambda$0.invoke(Unknown Source)
[error]         at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
[error]         at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
[error]         at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data.getModuleData(KDeclarationContainerImpl.kt:37)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.descriptor_delegate$lambda$0(KClassImpl.kt:69)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda1(KClassImpl.kt)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$1.invoke(Unknown Source)
[error]         at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
[error]         at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.getDescriptor(KClassImpl.kt:67)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.kmClass_delegate$lambda$0(KClassImpl.kt:62)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda0(KClassImpl.kt)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$0.invoke(Unknown Source)
[error]         at kotlin.SafePublicationLazyImpl.getValue(LazyJVM.kt:125)
[error]         at kotlin.reflect.jvm.internal.KClassImpl$Data.getKmClass(KClassImpl.kt:61)
[error]         at kotlin.reflect.jvm.internal.KClassImpl.getKmClass(KClassImpl.kt:228)
[error]         at kotlin.reflect.jvm.internal.KClassImpl.getModality(KClassImpl.kt:319)
[error]         at kotlin.reflect.jvm.internal.KClassImpl.isAbstract(KClassImpl.kt:334)
[error]         at io.kotest.runner.junit.platform.discovery.Discovery.isAbstract$lambda$0(Discovery.kt:33)
[error]         at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:204)
[error]         at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:227)
[error]         at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:202)
[error]         at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:227)
[error]         at kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:817)
[error]         at io.kotest.runner.junit.platform.discovery.Discovery.specsFromClasspathRootSelectors(Discovery.kt:92)
[error]         at io.kotest.runner.junit.platform.discovery.Discovery.discover(Discovery.kt:44)
[error]         at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:131)
[error]         at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:30)
[error]         at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:195)
[error]         at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely(EngineDiscoveryOrchestrator.java:174)
[error]         at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:119)
[error]         at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:84)
[error]         at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:119)
[error]         at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:85)
[error]         at org.junit.platform.launcher.core.DelegatingLauncher.discover(DelegatingLauncher.java:43)
[error]         at org.junit.platform.launcher.core.InterceptingLauncher.lambda$discover$0(InterceptingLauncher.java:35)
[error]         at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
[error]         at org.junit.platform.launcher.core.InterceptingLauncher.discover(InterceptingLauncher.java:35)
[error]         at org.junit.platform.launcher.core.DelegatingLauncher.discover(DelegatingLauncher.java:43)
[error]         at org.junit.platform.launcher.core.SessionPerRequestLauncher.discover(SessionPerRequestLauncher.java:60)
[error]         at com.github.sbt.junit.jupiter.api.JupiterTestCollector.collectTests0(JupiterTestCollector.java:234)
[error]         at com.github.sbt.junit.jupiter.api.JupiterTestCollector.invokeWithCustomClassLoader(JupiterTestCollector.java:301)
[error]         at com.github.sbt.junit.jupiter.api.JupiterTestCollector.collectTests(JupiterTestCollector.java:69)
[error]         at com.github.sbt.junit.jupiter.sbt.JupiterPlugin$.$anonfun$collectTests$1(JupiterPlugin.scala:107)
```

My short investigation showed that instead of discovering a standard library `kotlin.KotlinVersion` class ([this one](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-kotlin-version/)), it discovers `kotlin.KotlinVersion` from the plugin. Essentially there's a class name clash.

I naively propose we rename the class to mitigate the problem. But mainly I thought that it's worth to give you a heads up that this is ocuring.