### PR TITLE
Cross-compile the sbt-kotlin-plugin to Scala 3 and sbt 2 #SCL-24919

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: sbt-kotlin-plugin Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Compile & Test
-        run: sbt test scripted
+        run: sbt +test +scripted

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Build Kotlin code using sbt.
 ## Attribution
 
 `sbt-kotlin-plugin` started off as a fork of [kotlin-plugin](https://github.com/pfn/kotlin-plugin) but has been
-completely revamped with time and now shares almost no code with the original repository.
+completely revamped with time and now shares almost no code with the original repository. We thank the original
+authors and maintainers for their work.
 
 ## Requirement
 `sbt-kotlin-plugin` requires sbt 1.6 or later. Earlier sbt versions are not supported and will

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Build Kotlin code using sbt.
 
+The plugin is cross-published to:
+
+| sbt Version             | Published          |
+|-------------------------|--------------------|
+| 1.x (sbt 1.6+ required) | :white_check_mark: |
+| 2.x                     |                    |
+
 ## Attribution
 
 `sbt-kotlin-plugin` started off as a fork of [kotlin-plugin](https://github.com/pfn/kotlin-plugin) but has been

--- a/build.sbt
+++ b/build.sbt
@@ -14,5 +14,5 @@ lazy val sbtKotlinPlugin = project.in(file("."))
     },
     scalacOptions ++= Seq("-deprecation", "-feature", "-Werror", "-Xlint", "-release", "8"),
     javacOptions  ++= Seq("--release", "8"),
-    libraryDependencies += "org.scalameta" %% "munit" % "1.2.3" % Test
+    libraryDependencies += "org.scalameta" %% "munit" % "1.3.3" % Test
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+// This is a special plugin applied here, not in `project/plugins.sbt` because it needs to be available
+// to our sbt-kotlin-plugin's sources, not the meta-build.
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")
+
 ThisBuild / organization := "org.jetbrains.scala"
 
 lazy val sbtKotlinPlugin = project.in(file("."))
@@ -6,13 +10,35 @@ lazy val sbtKotlinPlugin = project.in(file("."))
   .settings(Publishing.settings)
   .settings(
     name := "sbt-kotlin-plugin",
-    crossScalaVersions := Seq("2.12.21"),
+    crossScalaVersions := Seq("2.12.21", "3.8.4"),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.6.0"
+        case "3" => "2.0.0"
       }
     },
-    scalacOptions ++= Seq("-deprecation", "-feature", "-Werror", "-Xlint", "-release", "8"),
-    javacOptions  ++= Seq("--release", "8"),
-    libraryDependencies += "org.scalameta" %% "munit" % "1.3.3" % Test
+    scalacOptions ++= {
+      val common = Seq("-deprecation", "-feature", "-Werror")
+      val versionSpecific = scalaBinaryVersion.value match {
+        case "2.12" => Seq("-Xlint", "-release", "8")
+        case "3" => Seq(
+          "-release", "17",
+          "-Wconf:msg=method reflectiveSelectableFromLangReflectiveCalls in object Selectable is deprecated:s"
+        )
+      }
+      common ++ versionSpecific
+    },
+    javacOptions ++= {
+      scalaBinaryVersion.value match {
+        case "2.12" => Seq("-release", "8")
+        case "3" => Seq("-release", "17")
+      }
+    },
+    libraryDependencies += "org.scalameta" %% "munit" % "1.3.3" % Test,
+    scriptedSbt := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.12.13"
+        case "3" => "2.0.1"
+      }
+    }
   )

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -14,6 +14,6 @@ object Scripted {
 
   val settings: Seq[Def.Setting[?]] = Seq(
     passPluginVersion,
-    forwardIvyHomeProperty,
+    forwardIvyHomeProperty
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.4
+sbt.version=1.12.13

--- a/src/main/scala-2.12/org/jetbrains/sbt/kotlin/ClasspathsCompat.scala
+++ b/src/main/scala-2.12/org/jetbrains/sbt/kotlin/ClasspathsCompat.scala
@@ -1,0 +1,13 @@
+package org.jetbrains.sbt.kotlin
+
+import sbt.Keys.Classpath
+import sbt.{Classpaths, Configuration, UpdateReport}
+import xsbti.FileConverter
+
+import scala.annotation.unused
+
+private[kotlin] object ClasspathsCompat {
+  def managedJars(config: Configuration, jarTypes: Set[String], up: UpdateReport)
+    (implicit @unused converter: FileConverter): Classpath =
+    Classpaths.managedJars(config, jarTypes, up)
+}

--- a/src/main/scala-2.12/org/jetbrains/sbt/kotlin/CompileIncrementalCompat.scala
+++ b/src/main/scala-2.12/org/jetbrains/sbt/kotlin/CompileIncrementalCompat.scala
@@ -1,0 +1,23 @@
+package org.jetbrains.sbt.kotlin
+
+import org.jetbrains.sbt.kotlin.Keys.*
+import sbt.*
+import sbt.Keys.*
+import xsbti.compile.CompileResult
+
+private[kotlin] object CompileIncrementalCompat {
+  def compileIncrementalTaskImpl: Def.Initialize[Task[CompileResult]] = Def.task {
+    KotlinCompile.compileIncremental(
+      streams = streams.value,
+      inputs = (compile / compileInputs).value,
+      converter = fileConverter.value,
+      kotlinVersion = kotlinVersion.value,
+      kotlincOptions = kotlincOptions.value,
+      kotlincJvmTarget = kotlincJvmTarget.value,
+      kotlinModuleName = kotlinModuleName.value,
+      kotlincPluginOptions = kotlincPluginOptions.value,
+      classpathOptions = classpathOptions.value,
+      compilerClasspath = (KotlinInternal / managedClasspath).value
+    )
+  }.tag(Tags.Compile, Tags.CPU)
+}

--- a/src/main/scala-2.12/org/jetbrains/sbt/kotlin/OrderingImplicitsCompat.scala
+++ b/src/main/scala-2.12/org/jetbrains/sbt/kotlin/OrderingImplicitsCompat.scala
@@ -1,0 +1,8 @@
+package org.jetbrains.sbt.kotlin
+
+import scala.language.higherKinds
+
+private[kotlin] object OrderingImplicitsCompat {
+  implicit def seqDerivedOrdering[CC[X] <: scala.collection.Seq[X], T](implicit ord: Ordering[T]): Ordering[CC[T]] =
+    scala.math.Ordering.Implicits.seqDerivedOrdering
+}

--- a/src/main/scala-2.12/org/jetbrains/sbt/kotlin/RemoteCache.scala
+++ b/src/main/scala-2.12/org/jetbrains/sbt/kotlin/RemoteCache.scala
@@ -11,7 +11,12 @@ private[kotlin] object RemoteCache {
   private final val KotlinModuleBackupDir = "_kotlin_module_backup_"
   private final val MetaInfDir = "META-INF"
 
-  def packageCacheTask: Def.Initialize[Task[File]] = Def.task {
+  def remoteCacheSettings: Seq[Setting[?]] = Seq(
+    packageCache := packageCacheTask.value,
+    pullRemoteCache := pullRemoteCacheTask.value
+  )
+
+  private def packageCacheTask: Def.Initialize[Task[File]] = Def.task {
     val cacheArtifact = packageCache.value
     val name = kotlinModuleName.value
     val kotlinModuleFileName = s"$name.kotlin_module"
@@ -25,7 +30,7 @@ private[kotlin] object RemoteCache {
     cacheArtifact
   }
 
-  def pullRemoteCacheTask: Def.Initialize[Task[Unit]] = Def.task {
+  private def pullRemoteCacheTask: Def.Initialize[Task[Unit]] = Def.task {
     pullRemoteCache.value
     val name = kotlinModuleName.value
     val kotlinModuleFileName = s"$name.kotlin_module"

--- a/src/main/scala-2.12/sbt/JavaAnalyzeBridge.scala
+++ b/src/main/scala-2.12/sbt/JavaAnalyzeBridge.scala
@@ -2,7 +2,7 @@ package sbt
 
 import sbt.internal.inc.classfile.JavaAnalyze
 import xsbti.compile.Output
-import xsbti.{VirtualFile, VirtualFileRef}
+import xsbti.{AnalysisCallback, VirtualFile, VirtualFileRef}
 
 object JavaAnalyzeBridge {
   def apply(
@@ -12,7 +12,7 @@ object JavaAnalyzeBridge {
     output: Output,
     finalJarOutput: Option[java.nio.file.Path]
   )(
-    analysis: xsbti.AnalysisCallback,
+    analysis: AnalysisCallback,
     loader: ClassLoader,
     readAPI: (VirtualFileRef, Seq[Class[?]]) => Set[(String, String)]
   ): Unit = JavaAnalyze(newClasses, sources, log, output, finalJarOutput)(analysis, loader, readAPI)

--- a/src/main/scala-3/org/jetbrains/sbt/kotlin/ClasspathsCompat.scala
+++ b/src/main/scala-3/org/jetbrains/sbt/kotlin/ClasspathsCompat.scala
@@ -1,0 +1,10 @@
+package org.jetbrains.sbt.kotlin
+
+import sbt.Keys.Classpath
+import sbt.{Classpaths, Configuration, UpdateReport}
+import xsbti.FileConverter
+
+private[kotlin] object ClasspathsCompat:
+  def managedJars(config: Configuration, jarTypes: Set[String], up: UpdateReport)
+    (using converter: FileConverter): Classpath =
+    Classpaths.managedJars(config, jarTypes, up, converter)

--- a/src/main/scala-3/org/jetbrains/sbt/kotlin/CompileIncrementalCompat.scala
+++ b/src/main/scala-3/org/jetbrains/sbt/kotlin/CompileIncrementalCompat.scala
@@ -1,0 +1,48 @@
+package org.jetbrains.sbt.kotlin
+
+import org.jetbrains.sbt.kotlin.Keys
+import sbt.*
+import sbt.Keys.*
+import sbt.internal.inc.MixedAnalyzingCompiler
+import sbt.util.CacheImplicits.given
+import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFileRef}
+import xsbti.compile.AnalysisContents
+
+private[kotlin] object CompileIncrementalCompat:
+  def compileIncrementalTaskImpl: Def.Initialize[Task[(Boolean, VirtualFileRef, HashedVirtualFileRef)]] = Def.cachedTask {
+    val inputs = (compile / compileInputs).value
+    // Magic task which needs to be called such that caching of tasks works correctly.
+    // Without this line, nothing ever gets recompiled, even when there are changes to source files.
+    val inputs2 = (compile / compileInputs2).value
+    val converter = fileConverter.value
+    val kotlinVersion = Keys.kotlinVersion.value
+    val kotlincOptions = Keys.kotlincOptions.value
+    val kotlincJvmTarget = Keys.kotlincJvmTarget.value
+    val kotlinModuleName = Keys.kotlinModuleName.value
+    val kotlincPluginOptions = Keys.kotlincPluginOptions.value
+    val analysisFile = compileAnalysisFile.value
+    val store = MixedAnalyzingCompiler.staticCachedStore(
+      analysisFile = analysisFile.toPath,
+      useTextAnalysis = false
+    )
+    val analysisResult = KotlinCompile.compileIncremental(
+      streams = sbt.Keys.streams.value,
+      inputs = inputs,
+      converter = converter,
+      kotlinVersion = kotlinVersion,
+      kotlincOptions = kotlincOptions,
+      kotlincJvmTarget = kotlincJvmTarget,
+      kotlinModuleName = kotlinModuleName,
+      kotlincPluginOptions = kotlincPluginOptions,
+      classpathOptions = inputs.compilers().scalac().classpathOptions(),
+      compilerClasspath = (Keys.KotlinInternal / managedClasspath).value
+    )
+    val analysisOut = converter.toVirtualFile(inputs.setup().cachePath())
+    val contents = AnalysisContents.create(analysisResult.analysis(), analysisResult.setup())
+    store.set(contents)
+    Def.declareOutput(analysisOut)
+    val dir = inputs.options().classesDirectory()
+    val vfDir = converter.toVirtualFile(dir)
+    val packedDir = Def.declareOutputDirectory(vfDir)
+    (analysisResult.hasModified(), vfDir, packedDir)
+  }.tag(Tags.Compile, Tags.CPU)

--- a/src/main/scala-3/org/jetbrains/sbt/kotlin/OrderingImplicitsCompat.scala
+++ b/src/main/scala-3/org/jetbrains/sbt/kotlin/OrderingImplicitsCompat.scala
@@ -1,0 +1,7 @@
+package org.jetbrains.sbt.kotlin
+
+import scala.language.higherKinds
+
+private[kotlin] object OrderingImplicitsCompat:
+  given seqDerivedOrdering: [CC[X] <: scala.collection.Seq[X], T] => Ordering[T] => Ordering[CC[T]] =
+    scala.math.Ordering.Implicits.seqOrdering

--- a/src/main/scala-3/org/jetbrains/sbt/kotlin/RemoteCache.scala
+++ b/src/main/scala-3/org/jetbrains/sbt/kotlin/RemoteCache.scala
@@ -1,0 +1,6 @@
+package org.jetbrains.sbt.kotlin
+
+import sbt.Setting
+
+private[kotlin] object RemoteCache:
+  def remoteCacheSettings: Seq[Setting[?]] = Seq.empty

--- a/src/main/scala-3/sbt/JavaAnalyzeBridge.scala
+++ b/src/main/scala-3/sbt/JavaAnalyzeBridge.scala
@@ -1,0 +1,31 @@
+package sbt
+
+import sbt.internal.inc.classfile.ClassFile
+import xsbti.compile.Output
+import xsbti.{AnalysisCallback, VirtualFile, VirtualFileRef}
+
+object JavaAnalyzeBridge:
+  def apply(
+    newClasses: Seq[java.nio.file.Path],
+    sources: Seq[VirtualFile],
+    log: Logger,
+    output: Output,
+    finalJarOutput: Option[java.nio.file.Path]
+  )(
+    analysis: xsbti.AnalysisCallback,
+    loader: ClassLoader,
+    readAPI: (VirtualFileRef, Seq[Class[?]]) => Set[(String, String)]
+  ): Unit =
+    val cls = Class.forName("sbt.internal.inc.classfile.JavaAnalyze")
+    val method = cls.getDeclaredMethods.find(_.getName == "apply").getOrElse(sys.error("Could not find JavaAnalyze.apply method"))
+    method.getParameterCount match
+      case 8 =>
+        // sbt 2 versions up to and including 2.0.0 have an apply method with 8 paremeters
+        method.invoke(null, newClasses, sources, log, output, finalJarOutput, analysis, loader, readAPI)
+      case 10 =>
+        // sbt 2.0.1 and up have an apply method with 10 parameters
+        val readClassfileAPI: (VirtualFileRef, Seq[(String, ClassFile)]) => Unit = (_, _) => ()
+        val constantDeps = Map.empty[String, Set[String]]
+        method.invoke(null, newClasses, sources, log, output, finalJarOutput, analysis, loader, readAPI, readClassfileAPI, constantDeps)
+      case n =>
+        sys.error(s"Unrecognized JavaAnalyze.apply method with $n parameters: $method")

--- a/src/main/scala/org/jetbrains/sbt/kotlin/AnalyzingKotlinCompiler.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/AnalyzingKotlinCompiler.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters.*
  * the source code of `sbt.internal.inc.javac.AnalyzingJavaCompiler`, as seen in
  * https://github.com/sbt/zinc/blob/7aa92cb48872f28dd44c1bb7520a84a0e02f230e/zinc/src/main/scala/sbt/internal/inc/javac/AnalyzingJavaCompiler.scala.
  */
-class AnalyzingKotlinCompiler(
+private final class AnalyzingKotlinCompiler(
   kotlinVersion: String,
   kotlinOptions: Seq[String],
   jvmTarget: String,
@@ -106,7 +106,7 @@ class AnalyzingKotlinCompiler(
         log.debug(s"compiling Kotlin sources: $kotlinSources")
 
         timed(kotlinCompilationPhase, log) {
-          val stub = KotlinStub(log, KotlinCompile.memoizedKotlinReflection(compilerClasspath))
+          val stub = new KotlinStub(log, KotlinCompile.memoizedKotlinReflection(compilerClasspath))
           val args = stub.compilerArgs
           stub.parse(kotlinVersion, args.instance, "-Xallow-no-source-files" :: kotlinOptions.toList)
           args.multiPlatform = false
@@ -231,7 +231,7 @@ class AnalyzingKotlinCompiler(
     }
 
   /** Time how long it takes to run various compilation tasks. */
-  private[this] def timed[T](label: String, log: Logger)(t: => T): T = {
+  private def timed[T](label: String, log: Logger)(t: => T): T = {
     val start = System.nanoTime
     val result = t
     val elapsed = System.nanoTime - start

--- a/src/main/scala/org/jetbrains/sbt/kotlin/CompilerArgs.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/CompilerArgs.scala
@@ -5,7 +5,7 @@ import scala.language.dynamics
 /**
  * Encapsulates reflective access to the Kotlin compiler internal args class.
  */
-final class CompilerArgs(kref: KotlinReflection) extends Dynamic {
+private final class CompilerArgs(kref: KotlinReflection) extends Dynamic {
   val instance: AnyRef = kref.compilerArgsClass.getDeclaredConstructor().newInstance().asInstanceOf[AnyRef]
 
   def selectDynamic[A](field: String): A = {
@@ -28,5 +28,5 @@ final class CompilerArgs(kref: KotlinReflection) extends Dynamic {
 
   private def getterName(field: String) = s"get${withFirstUpper(field)}"
   private def setterName(field: String) = s"set${withFirstUpper(field)}"
-  private def withFirstUpper(string: String): String = string.head.toUpper + string.tail
+  private def withFirstUpper(string: String): String = string.head.toUpper.toString ++ string.tail
 }

--- a/src/main/scala/org/jetbrains/sbt/kotlin/Keys.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/Keys.scala
@@ -1,6 +1,8 @@
 package org.jetbrains.sbt.kotlin
 
 import sbt.{Def, *}
+import sbtcompat.PluginCompat.toNioPaths
+import xsbti.FileConverter
 
 object Keys {
   val Kotlin = config("kotlin")
@@ -27,10 +29,10 @@ object Keys {
   def kotlinPlugin(name: String): Def.Setting[Seq[ModuleID]] = sbt.Keys.libraryDependencies +=
     "org.jetbrains.kotlin" % ("kotlin-" + name) % kotlinVersion.value % "compile-internal"
 
-  def kotlinClasspath(config: Configuration, classpathKey: Def.Initialize[sbt.Keys.Classpath]): Setting[?] =
+  def kotlinClasspath(config: Configuration, classpathKey: Def.Initialize[sbt.Keys.Classpath])(implicit converter: FileConverter): Setting[?] =
     config / kotlincOptions ++= {
       "-cp" ::
-        classpathKey.value.map(_.data.getAbsolutePath).mkString(java.io.File.pathSeparator) ::
+        toNioPaths(classpathKey.value).map(_.toAbsolutePath.normalize().toString).mkString(java.io.File.pathSeparator) ::
         Nil
     }
 

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinCompile.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinCompile.scala
@@ -1,15 +1,15 @@
 package org.jetbrains.sbt.kotlin
 
-import org.jetbrains.sbt.kotlin.Keys.*
-import sbt.*
 import sbt.Keys.*
 import sbt.internal.inc.*
 import sbt.internal.inc.caching.ClasspathCache
+import sbtcompat.PluginCompat.toNioPaths
+import xsbti.FileConverter
 import xsbti.compile.*
 
 import java.nio.file.{Files, Path}
 
-object KotlinCompile {
+private[kotlin] object KotlinCompile {
 
   private def memoize[K, V](f: K => V): K => V = {
     val cache = new java.util.concurrent.ConcurrentHashMap[K, V]()
@@ -20,10 +20,18 @@ object KotlinCompile {
   private[kotlin] lazy val memoizedKotlinReflection =
     memoize[Seq[Path], KotlinReflection](KotlinReflection.fromClasspath)
 
-  def compileTask: Def.Initialize[Task[CompileResult]] = Def.task {
-    val log = streams.value.log
-    val inputs = (compile / compileInputs).value
-    val converter = inputs.options().converter().orElse(PlainVirtualFileConverter.converter)
+  private[kotlin] def compileIncremental(
+    streams: TaskStreams,
+    inputs: Inputs,
+    converter: FileConverter,
+    kotlinVersion: String,
+    kotlincOptions: Seq[String],
+    kotlincJvmTarget: String,
+    kotlinModuleName: String,
+    kotlincPluginOptions: Seq[String],
+    classpathOptions: ClasspathOptions,
+    compilerClasspath: Classpath
+  ): CompileResult = {
     val out = inputs.options().classesDirectory().toAbsolutePath.normalize()
 
     val srcs = inputs.options().sources().toSet
@@ -33,8 +41,6 @@ object KotlinCompile {
       override def getOutputDirectoryAsPath: Path = out
     }
 
-    val kotlincVersion = kotlinVersion.value
-
     val previousResult = inputs.previousResult()
     val previousAnalysis = previousResult.analysis().orElse(Analysis.empty)
 
@@ -43,6 +49,8 @@ object KotlinCompile {
     val classpathAsNioPaths = classpathIndexedSeq.map(converter.toPath(_).toAbsolutePath.normalize())
 
     val stamper = inputs.options().stamper().orElseGet(() => Stamps.timeWrapBinaryStamps(converter))
+
+    val javacOptionsAsIndexedSeq = inputs.options().javacOptions().toIndexedSeq
 
     val config = {
       val outputJarContent = JarUtils.createOutputJarContent(output)
@@ -55,8 +63,8 @@ object KotlinCompile {
         classpathIndexedSeq,
         inputs.setup().cache(),
         optionalToOption(inputs.setup().progress()),
-        inputs.options().scalacOptions(),
-        inputs.options().javacOptions(),
+        inputs.options().scalacOptions().toIndexedSeq,
+        javacOptionsAsIndexedSeq,
         previousAnalysis,
         optionalToOption(previousResult.setup()),
         inputs.setup().perClasspathEntryLookup(),
@@ -86,7 +94,7 @@ object KotlinCompile {
     val miniSetup = MiniSetup.of(
       output,
       MiniOptions.of(classpathHash, inputs.options().scalacOptions(), inputs.options().javacOptions()),
-      kotlincVersion,
+      kotlinVersion,
       inputs.options().order(),
       true,
       inputs.setup().extra()
@@ -98,29 +106,31 @@ object KotlinCompile {
       Files.createDirectories(out)
     }
 
-    val compilerClasspath: Seq[Path] =
-      (KotlinInternal / managedClasspath).value.map(_.data.toPath.toAbsolutePath.normalize())
+    val compilerClasspathAsNioPaths = {
+      implicit val c: FileConverter = converter
+      toNioPaths(compilerClasspath)
+    }
 
     val compiler = new AnalyzingKotlinCompiler(
-      kotlincVersion,
-      kotlincOptions.value,
-      kotlincJvmTarget.value,
-      kotlinModuleName.value,
-      kotlincPluginOptions.value,
+      kotlinVersion,
+      kotlincOptions,
+      kotlincJvmTarget,
+      kotlinModuleName,
+      kotlincPluginOptions,
       inputs.compilers().javaTools().javac(),
-      inputs.options().javacOptions(),
+      javacOptionsAsIndexedSeq,
       inputs.compilers().scalac().scalaInstance(),
       inputs.setup().incrementalCompilerOptions().useCustomizedFileManager(),
       config.sources,
-      classpathOptions.value,
+      classpathOptions,
       classpathAsNioPaths,
-      compilerClasspath,
+      compilerClasspathAsNioPaths,
       searchClasspath,
       output,
       converter,
       inputs.setup().reporter(),
       config.progress,
-      log
+      streams.log
     )
 
     val (success, analysis) = Incremental(
@@ -136,7 +146,7 @@ object KotlinCompile {
       None,
       None,
       config.progress,
-      log,
+      streams.log
     )(compiler.compile)
 
     CompileResult.of(analysis, miniSetup, success)

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinPlugin.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinPlugin.scala
@@ -4,6 +4,8 @@ import org.jetbrains.sbt.kotlin.Keys.*
 import sbt.Keys.*
 import sbt.plugins.JvmPlugin
 import sbt.{Def, Keys as _, *}
+import sbtcompat.PluginCompat.*
+import xsbti.FileConverter
 
 object KotlinPlugin extends AutoPlugin {
   override def trigger = noTrigger
@@ -33,17 +35,19 @@ object KotlinPlugin extends AutoPlugin {
     libraryDependencies ++= Seq(
       "org.jetbrains.kotlin" % "kotlin-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name
     ) ++ kotlinScriptCompilerDeps(kotlinVersion.value, kotlinRuntimeProvided.value),
-    KotlinInternal / managedClasspath := Classpaths.managedJars(KotlinInternal, classpathTypes.value, update.value),
+    KotlinInternal / managedClasspath := Def.uncached {
+      implicit val converter: FileConverter = fileConverter.value
+      ClasspathsCompat.managedJars(KotlinInternal, classpathTypes.value, update.value)
+    },
     kotlinVersion := "1.3.50",
     kotlincJvmTarget := "1.6",
     kotlinRuntimeProvided := false,
     kotlincOptions := Nil,
     kotlincPluginOptions := Nil,
-    watchSources ++= {
-      import language.postfixOps
+    watchSources ++= Def.uncached {
       val kotlinSources = "*.kt" || "*.kts"
-      (Compile / sourceDirectories).value.flatMap(_ ** kotlinSources get) ++
-        (Test / sourceDirectories).value.flatMap(_ ** kotlinSources get)
+      (Compile / sourceDirectories).value.flatMap(d => (d ** kotlinSources).get()) ++
+        (Test / sourceDirectories).value.flatMap(d => (d ** kotlinSources).get())
     }
   ) ++ inConfig(Compile)(kotlinCompileSettings) ++
     inConfig(Test)(kotlinCompileSettings)
@@ -65,9 +69,7 @@ object KotlinPlugin extends AutoPlugin {
       s"$name.$config"
     },
     kotlincPluginOptions := kotlincPluginOptions.value,
-    compileIncremental := KotlinCompile.compileTask.value,
-    kotlinSource := sourceDirectory.value / "kotlin",
-    packageCache := RemoteCache.packageCacheTask.value,
-    pullRemoteCache := RemoteCache.pullRemoteCacheTask.value
-  )
+    compileIncremental := Def.uncached(CompileIncrementalCompat.compileIncrementalTaskImpl.value),
+    kotlinSource := sourceDirectory.value / "kotlin"
+  ) ++ RemoteCache.remoteCacheSettings
 }

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinReflection.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinReflection.scala
@@ -6,7 +6,7 @@ import java.lang.reflect.{Field, Method}
 import java.nio.file.Path
 import scala.util.Try
 
-object KotlinReflection {
+private object KotlinReflection {
   def fromClasspath(cp: Seq[Path]): KotlinReflection = {
     val cl = ClasspathUtil.toLoader(cp)
     val compilerClass = cl.loadClass("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
@@ -40,7 +40,7 @@ object KotlinReflection {
   }
 }
 
-case class KotlinReflection(
+private final case class KotlinReflection(
   cl: ClassLoader,
   servicesClass: Class[?],
   compilerClass: Class[?],

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinStub.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinStub.scala
@@ -3,9 +3,9 @@ package org.jetbrains.sbt.kotlin
 import sbt.util.Logger
 
 import java.lang.reflect.Method
-import scala.jdk.CollectionConverters.seqAsJavaListConverter
+import scala.jdk.CollectionConverters.*
 
-case class KotlinStub(log: Logger, kref: KotlinReflection) {
+private final class KotlinStub(log: Logger, kref: KotlinReflection) {
   import kref.*
 
   def messageCollector: AnyRef = {

--- a/src/main/scala/org/jetbrains/sbt/kotlin/KotlinVersion.scala
+++ b/src/main/scala/org/jetbrains/sbt/kotlin/KotlinVersion.scala
@@ -1,10 +1,12 @@
 package org.jetbrains.sbt.kotlin
 
+import org.jetbrains.sbt.kotlin.OrderingImplicitsCompat.seqDerivedOrdering
+
 import scala.math.Ordered.orderingToOrdered
-import scala.math.Ordering.Implicits.seqDerivedOrdering
+import scala.util.matching.Regex
 
 // based on https://github.com/JetBrains/intellij-community/blob/c8ba8401f73488f966b5ed5b5c5afaa38a9bcbdf/plugins/kotlin/base/plugin/src/org/jetbrains/kotlin/idea/compiler/configuration/IdeKotlinVersion.kt#L24
-final class KotlinVersion private[kotlin](val major: Int, val minor: Int, val patch: Int,
+private final class KotlinVersion private[kotlin](val major: Int, val minor: Int, val patch: Int,
                                           val kindSuffix: KotlinVersion.Kind,
                                           val buildNumber: Option[String]) extends Ordered[KotlinVersion] {
   override def compare(that: KotlinVersion): Int = {
@@ -22,9 +24,11 @@ final class KotlinVersion private[kotlin](val major: Int, val minor: Int, val pa
   }
 }
 
-object KotlinVersion {
-  private val kotlinVersionRegex = "^(\\d+)\\.(\\d+)\\.(\\d+)(?:-([A-Za-z]\\w+(?:\\.\\d+)?(?:-release)?))?(?:-(\\d+)?)?$"
-    .r("major", "minor", "patch", "kindSuffix", "buildNumber")
+private object KotlinVersion {
+  private val kotlinVersionRegex: Regex = new Regex(
+    regex = "^(\\d+)\\.(\\d+)\\.(\\d+)(?:-([A-Za-z]\\w+(?:\\.\\d+)?(?:-release)?))?(?:-(\\d+)?)?$",
+    groupNames = "major", "minor", "patch", "kindSuffix", "buildNumber"
+  )
 
   private val IdeBuildRegex = "ij\\d+(?:\\.\\d+)?".r
 
@@ -42,13 +46,13 @@ object KotlinVersion {
         case Some("snapshot") | Some("local") =>
           Some(Kind.Snapshot)
         case Some(suffix) if suffix.startsWith("rc") =>
-          parseKind(suffix, "rc")(Kind.ReleaseCandidate)
+          parseKind(suffix, "rc")(Kind.ReleaseCandidate.apply)
         case Some(suffix) if suffix.startsWith("beta") =>
-          parseKind(suffix, "beta")(Kind.Beta)
+          parseKind(suffix, "beta")(Kind.Beta.apply)
         case Some(suffix) if suffix.startsWith("eap") =>
-          parseKind(suffix, "eap")(Kind.Eap)
+          parseKind(suffix, "eap")(Kind.Eap.apply)
         case Some(suffix) if suffix.startsWith("m") =>
-          parseKind(suffix, "m")(Kind.Milestone)
+          parseKind(suffix, "m")(Kind.Milestone.apply)
         case Some(suffix) if suffix.matches(IdeBuildRegex.regex) =>
           val parts = suffix.stripPrefix("ij").split('.').toSeq.map(_.toInt)
           Some(Kind.ForIde(suffix, parts))

--- a/src/sbt-test/kotlin/basic-tests/build.sbt
+++ b/src/sbt-test/kotlin/basic-tests/build.sbt
@@ -1,7 +1,8 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 import sbt.complete.Parsers.spaceDelimited
 
+import java.nio.file.{Files, Path}
 import scala.xml.{NodeSeq, XML}
 
 name := "basic-tests"
@@ -18,7 +19,15 @@ checkTestPass := {
   val args: Seq[String] = spaceDelimited("<arg>").parsed
   val testName = args.head
 
-  val xml = XML.load(s"target/test-reports/TEST-$testName.xml")
+  val testReportPath = {
+    val xmlFileName = s"TEST-$testName.xml"
+    val sbt1 = Option(Path.of("target", "test-reports", xmlFileName)).filter(Files.exists(_))
+    val converter = fileConverter.value
+    val sbt2 = Option(converter.toPath((Test / backendOutput).value).getParent.resolve("test-reports").resolve(xmlFileName)).filter(Files.exists(_))
+    sbt1.orElse(sbt2).getOrElse(sys.error("Could not find test report xml file")).toAbsolutePath.normalize().toString
+  }
+
+  val xml = XML.load(testReportPath)
   val totalTests = getInt(xml \\ "testsuite" \ "@tests")
   val failures = getInt(xml \\ "testsuite" \ "@failures")
   val errors = getInt(xml \\ "testsuite" \ "@errors")

--- a/src/sbt-test/kotlin/basic-tests/test
+++ b/src/sbt-test/kotlin/basic-tests/test
@@ -1,7 +1,7 @@
 > compile
 > test
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/test-classes/demo/SimpleTest.class
-$ exists target/classes/META-INF/basic-tests.main.kotlin_module
-$ exists target/test-classes/META-INF/basic-tests.test.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/test-classes/demo/SimpleTest.class
+$ exists target/**/classes/META-INF/basic-tests.main.kotlin_module
+$ exists target/**/test-classes/META-INF/basic-tests.test.kotlin_module
 > checkTestPass "demo.SimpleTest"

--- a/src/sbt-test/kotlin/basic/build.sbt
+++ b/src/sbt-test/kotlin/basic/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "basic"
 

--- a/src/sbt-test/kotlin/basic/test
+++ b/src/sbt-test/kotlin/basic/test
@@ -1,3 +1,3 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/META-INF/basic.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/META-INF/basic.main.kotlin_module

--- a/src/sbt-test/kotlin/compilation-cache/build.sbt
+++ b/src/sbt-test/kotlin/compilation-cache/build.sbt
@@ -1,5 +1,4 @@
 import org.jetbrains.sbt.kotlin.Keys.*
-import sbt.internal.util.ConsoleAppender
 
 import java.io.PrintWriter
 import java.nio.file.Files
@@ -16,6 +15,5 @@ libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
 
 ThisBuild / pushRemoteCacheTo := {
   val tmpDir = Files.createTempDirectory("compilation-cache-").toRealPath()
-  sLog.value.info(tmpDir.toString)
   Some(MavenCache("compilation-cache", tmpDir.toFile))
 }

--- a/src/sbt-test/kotlin/compilation-cache/project/build.properties
+++ b/src/sbt-test/kotlin/compilation-cache/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.13

--- a/src/sbt-test/kotlin/compiler-error/test
+++ b/src/sbt-test/kotlin/compiler-error/test
@@ -1,5 +1,5 @@
 -> compile
-$ absent target/classes/demo/SimpleError.class
-$ absent target/classes/META-INF/compiler-error.main.kotlin_module
-$ exists target/file-log/log.txt
+$ absent target/**/classes/demo/SimpleError.class
+$ absent target/**/classes/META-INF/compiler-error.main.kotlin_module
+$ exists target/**/file-log/log.txt
 > assertCompilerError

--- a/src/sbt-test/kotlin/incremental/build.sbt
+++ b/src/sbt-test/kotlin/incremental/build.sbt
@@ -22,6 +22,7 @@ extraAppenders := {
   (key: ScopedKey[?]) => appender +: existing(key)
 }
 
+@transient
 lazy val backupClasses = taskKey[Unit]("Backup compiled class files")
 
 backupClasses := {
@@ -38,6 +39,7 @@ backupClasses := {
   toBackup.foreach { path => Files.copy(path, backupClassesDir.resolve(path.getFileName)) }
 }
 
+@transient
 lazy val assertClassesContents = taskKey[Unit]("Assert compiled classes contents")
 
 assertClassesContents := {

--- a/src/sbt-test/kotlin/incremental/test
+++ b/src/sbt-test/kotlin/incremental/test
@@ -1,13 +1,13 @@
 > compile
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/MainKt.class
-$ absent target/classes/demo/Foo.class
-$ exists target/classes/META-INF/incremental.main.kotlin_module
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/MainKt.class
+$ absent target/**/classes/demo/Foo.class
+$ exists target/**/classes/META-INF/incremental.main.kotlin_module
 > backupClasses
 $ copy-file changes/main.kt src/main/kotlin/demo/main.kt
 $ copy-file changes/Foo.kt src/main/kotlin/demo/Foo.kt
 > compile
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/MainKt.class
-$ exists target/classes/demo/Foo.class
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/MainKt.class
+$ exists target/**/classes/demo/Foo.class
 > assertClassesContents

--- a/src/sbt-test/kotlin/kotlin-1.2-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-1.2-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-1.2-compat"
 

--- a/src/sbt-test/kotlin/kotlin-1.2-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.2-compat/test
@@ -1,7 +1,7 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ exists target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-1-2-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ exists target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-1-2-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-1.3-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-1.3-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-1.3-compat"
 

--- a/src/sbt-test/kotlin/kotlin-1.3-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.3-compat/test
@@ -1,7 +1,7 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ exists target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-1-3-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ exists target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-1-3-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-1.8-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-1.8-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-1.8-compat"
 

--- a/src/sbt-test/kotlin/kotlin-1.8-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.8-compat/test
@@ -1,9 +1,9 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/Vehicle.class
-$ exists target/classes/demo/HighQuality.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ exists target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-1-8-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/Vehicle.class
+$ exists target/**/classes/demo/HighQuality.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ exists target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-1-8-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-1.9-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-1.9-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-1.9-compat"
 

--- a/src/sbt-test/kotlin/kotlin-1.9-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.9-compat/test
@@ -1,9 +1,9 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/Color.class
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ absent target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-1-9-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/Color.class
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ absent target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-1-9-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-2.0-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-2.0-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-2.0-compat"
 

--- a/src/sbt-test/kotlin/kotlin-2.0-compat/test
+++ b/src/sbt-test/kotlin/kotlin-2.0-compat/test
@@ -1,9 +1,9 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/Color.class
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ absent target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-2-0-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/Color.class
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ absent target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-2-0-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-2.2-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-2.2-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-2.2-compat"
 

--- a/src/sbt-test/kotlin/kotlin-2.2-compat/test
+++ b/src/sbt-test/kotlin/kotlin-2.2-compat/test
@@ -1,9 +1,9 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/Color.class
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ absent target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-2-2-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/Color.class
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ absent target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-2-2-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-2.3-compat/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-2.3-compat/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-2.3-compat"
 

--- a/src/sbt-test/kotlin/kotlin-2.3-compat/test
+++ b/src/sbt-test/kotlin/kotlin-2.3-compat/test
@@ -1,9 +1,9 @@
 > compile
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/demo/Color.class
-$ exists target/classes/demo/Person.class
-$ exists target/classes/demo/AsyncInterface.class
-$ exists target/classes/demo/AsyncInterface$asyncString$1.class
-$ exists target/classes/demo/AsyncInterface$DefaultImpls.class
-$ absent target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-2-3-compat.main.kotlin_module
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/demo/Color.class
+$ exists target/**/classes/demo/Person.class
+$ exists target/**/classes/demo/AsyncInterface.class
+$ exists target/**/classes/demo/AsyncInterface$asyncString$1.class
+$ exists target/**/classes/demo/AsyncInterface$DefaultImpls.class
+$ absent target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-2-3-compat.main.kotlin_module

--- a/src/sbt-test/kotlin/kotlin-script/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-script/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "kotlin-script"
 

--- a/src/sbt-test/kotlin/kotlin-script/test
+++ b/src/sbt-test/kotlin/kotlin-script/test
@@ -1,3 +1,3 @@
 > compile
-$ exists target/classes/SimpleScript.class
-$ exists target/classes/META-INF/kotlin-script.main.kotlin_module
+$ exists target/**/classes/SimpleScript.class
+$ exists target/**/classes/META-INF/kotlin-script.main.kotlin_module

--- a/src/sbt-test/kotlin/mixed-tests/build.sbt
+++ b/src/sbt-test/kotlin/mixed-tests/build.sbt
@@ -1,7 +1,7 @@
-import org.jetbrains.sbt.kotlin.Keys._
-
+import org.jetbrains.sbt.kotlin.Keys.*
 import sbt.complete.Parsers.spaceDelimited
 
+import java.nio.file.{Files, Paths}
 import scala.xml.{NodeSeq, XML}
 
 name := "mixed-tests"
@@ -18,7 +18,15 @@ checkTestPass := {
   val args: Seq[String] = spaceDelimited("<arg>").parsed
   val testName = args.head
 
-  val xml = XML.load(s"target/test-reports/TEST-$testName.xml")
+  val testReportPath = {
+    val xmlFileName = s"TEST-$testName.xml"
+    val sbt1 = Option(Paths.get("target", "test-reports", xmlFileName)).filter(Files.exists(_))
+    val converter = fileConverter.value
+    val sbt2 = Option(converter.toPath((Test / backendOutput).value).getParent.resolve("test-reports").resolve(xmlFileName)).filter(Files.exists(_))
+    sbt1.orElse(sbt2).getOrElse(sys.error("Could not find test report xml file")).toAbsolutePath.normalize().toString
+  }
+
+  val xml = XML.load(testReportPath)
   val totalTests = getInt(xml \\ "testsuite" \ "@tests")
   val failures = getInt(xml \\ "testsuite" \ "@failures")
   val errors = getInt(xml \\ "testsuite" \ "@errors")

--- a/src/sbt-test/kotlin/mixed-tests/test
+++ b/src/sbt-test/kotlin/mixed-tests/test
@@ -1,8 +1,8 @@
 > compile
 > test
-$ exists target/classes/demo/JavaCalculator.class
-$ exists target/classes/demo/Calculator.class
-$ exists target/test-classes/demo/MixedTest.class
-$ exists target/classes/META-INF/mixed-tests.main.kotlin_module
-$ exists target/test-classes/META-INF/mixed-tests.test.kotlin_module
+$ exists target/**/classes/demo/JavaCalculator.class
+$ exists target/**/classes/demo/Calculator.class
+$ exists target/**/test-classes/demo/MixedTest.class
+$ exists target/**/classes/META-INF/mixed-tests.main.kotlin_module
+$ exists target/**/test-classes/META-INF/mixed-tests.test.kotlin_module
 > checkTestPass "demo.MixedTest"

--- a/src/sbt-test/kotlin/mixed/build.sbt
+++ b/src/sbt-test/kotlin/mixed/build.sbt
@@ -1,4 +1,4 @@
-import org.jetbrains.sbt.kotlin.Keys._
+import org.jetbrains.sbt.kotlin.Keys.*
 
 name := "mixed"
 

--- a/src/sbt-test/kotlin/mixed/test
+++ b/src/sbt-test/kotlin/mixed/test
@@ -1,8 +1,8 @@
 > compile
-$ exists target/classes/demo/JavaA.class
-$ exists target/classes/demo/JavaB.class
-$ exists target/classes/demo/KotlinA.class
-$ exists target/classes/demo/KotlinB.class
-$ exists target/classes/demo/SimpleKt.class
-$ exists target/classes/Script.class
-$ exists target/classes/META-INF/mixed.main.kotlin_module
+$ exists target/**/classes/demo/JavaA.class
+$ exists target/**/classes/demo/JavaB.class
+$ exists target/**/classes/demo/KotlinA.class
+$ exists target/**/classes/demo/KotlinB.class
+$ exists target/**/classes/demo/SimpleKt.class
+$ exists target/**/classes/Script.class
+$ exists target/**/classes/META-INF/mixed.main.kotlin_module


### PR DESCRIPTION
Cross-compile the `sbt-kotlin-plugin` to Scala 3 and sbt 2. With this change, all scripted tests still pass for both sbt 1 and sbt 2.

Apart from the old compilation cache setup, everything should work exactly the same.

A note on compilation caching. Sbt 2 completely revamped and remove the old compilation caching mechanism from sbt 1. In sbt 1, there were specific tasks used for pushing and restoring the compilation outputs as `.jar` files to and from a remote Maven repository. This no longer exists in sbt 2 as a concept.

Instead, sbt 2 allows the caching of any task output to a remote Bazel-compatible cache. Theoretically, this is already implemented correctly and working for `sbt-kotlin-plugin`, including making the incremental compilation task cacheable, similar to the Scala/Java incremental compilation task in sbt. Unfortunately, this is not so easy to verify at the moment, as sbt 2 remote caching still hasn't been adopted widely.

In any case, this should not delay the release of the plugin. Over time, we can further optimize the task implementations and verify that remote caching works as expected for sbt 2 as well.

https://youtrack.jetbrains.com/issue/SCL-24919/Modernize-the-sbt-kotlin-plugin-and-cross-compile-it-to-sbt-2