### PR TITLE
Run sbt 2 scripted tests against sbt 2.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val sbtKotlinPlugin = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.12.13"
-        case "3" => "2.0.1"
+        case "3" => "2.0.2"
       }
     }
   )


### PR DESCRIPTION
Bumps the scriptedSbt version for the Scala 3 / sbt 2 cross-build axis from 2.0.1 to 2.0.2, so the plugin's scripted tests exercise the latest sbt 2.0.x release. The sbt 1.x axis (1.12.13) and the minimum supported sbt 2 version for publishing (pluginCrossBuild / sbtVersion = 2.0.0) are unchanged.

Verified locally on JDK 17:
- sbt ++2.12.x test scripted — all 16 scripted tests pass
- sbt ++3.x test scripted — 15/15 scripted tests pass against sbt 2.0.2 (compilation-cache remains skipped on sbt 2, as before)

🤖 Generated with Claude Code