### PR TITLE
Update sbt to 1.12.14 and run scripted tests against sbt 1.12.14 / 2.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ lazy val sbtKotlinPlugin = project.in(file("."))
     libraryDependencies += "org.scalameta" %% "munit" % "1.3.3" % Test,
     scriptedSbt := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.12.13"
-        case "3" => "2.0.2"
+        case "2.12" => "1.12.14"
+        case "3" => "2.0.3"
       }
     }
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=1.12.14

--- a/src/sbt-test/kotlin/compilation-cache/project/build.properties
+++ b/src/sbt-test/kotlin/compilation-cache/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=1.12.14


### PR DESCRIPTION
## What

- Update the project (meta-build) sbt version from 1.12.13 to 1.12.14, the latest sbt 1.x release.
- Bump the scripted test sbt versions:
  - sbt 1.x line (Scala 2.12 cross): 1.12.13 → 1.12.14
  - sbt 2 line (Scala 3 cross): 2.0.2 → 2.0.3
  - This includes the `compilation-cache` test's own `project/build.properties`, which pins its sbt version explicitly.

## Verification

Ran the full CI matrix locally on JDK 17 (Temurin 17.0.19):

- `sbt ++2.12.x test scripted` — all unit tests and 16/16 scripted tests pass against sbt 1.12.14
- `sbt ++3.x test scripted` — all unit tests and 15/15 scripted tests pass against sbt 2.0.3