### PR TITLE
Run sbt 2 scripted tests against sbt 2.0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val sbtKotlinPlugin = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.12.14"
-        case "3" => "2.0.3"
+        case "3" => "2.0.4"
       }
     }
   )


### PR DESCRIPTION
sbt 2.0.4 was released on 2026-07-26. This updates `scriptedSbt` for the Scala 3 / sbt 2 cross-build from 2.0.3 to 2.0.4.

sbt 1.12.14 remains the latest sbt 1.x release, so the sbt 1 scripted version is unchanged.

Verified locally on Java 17: all 15 sbt 2 scripted tests pass against the 2.0.4 launcher.