### PR TITLE
Run sbt 2 scripted tests against sbt 2.0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val sbtKotlinPlugin = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.12.14"
-        case "3" => "2.0.4"
+        case "3" => "2.0.5"
       }
     }
   )


### PR DESCRIPTION
Bumps the sbt version used for the sbt 2 scripted tests from 2.0.4 to 2.0.5,
the latest release. The latest sbt 1.x is still 1.12.14, so the sbt 1 side is
unchanged.

Verified locally with Temurin JDK 17: both `++2.12.x test scripted` (16/16
scripted tests) and `++3.x test scripted` (15/15 scripted tests, running on
the sbt 2.0.5 launcher) pass.